### PR TITLE
Fix escaping of braces in pre-commit hash step in linting workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ '{{' }} hashFiles('.pre-commit-config.yaml') {{ '}}' }}
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ on:
       - "LICENSE"
       - ".github/release.yml"
       - ".github/dependabot.yml"
+      - ".github/workflows/docs.yml"
+      - ".github/workflows/linting.yml"
+      - ".github/workflows/pypi-publish.yml"
   schedule:
     - cron: "0 0 * * 1"
 


### PR DESCRIPTION
Braces `{{` unnecessarily escaped giving incorrect computation of hash key