### PR TITLE
Add contributor guidelines and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement using contact details
+at https://matt-graham.github.io/#contact.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+We welcome contributions of all forms to Mici.
+All contributors are expected to abide by the [code of conduct](CODE_OF_CONDUCT.md).
+
+If you don't have time to contribute but would like to show your support,
+[starring](https://github.com/matt-graham/mici/stargazers) the repository or posting about it on social media is always appreciated!
+
+## Reporting a bug or making a feature request
+
+If you have a question please first check if it is covered in the [documentation](https://matt-graham.github.io/mici/)
+or if there is an [existing issue](https://github.com/matt-graham/mici/issues) which answers your query.
+
+If there is not a relevant existing issue, to report a problem you are having with the package
+or request a new feature please [raise an issue](https://github.com/matt-graham/mici/issues/new/choose).
+
+When reporting a bug, please described the expected behaviour and what you actual observe,
+and sufficient information for someone else to _reproduce_ the problem. Ideally this
+should be in the form of a [_minimal reproducible example_](https://en.wikipedia.org/wiki/Minimal_reproducible_example)
+which reproduces the error while as being as small and simple as possible.
+
+## Making a contribution
+
+We use a _fork_ and _pull-request_ model for external contributions.
+Before opening a pull request that proposes substantial changes to the repository,
+for example adding a new feature or changing the public interface of the package,
+please first [raise an issue](https://github.com/matt-graham/mici/issues/new/choose) outlining the problem the proposed changes would address
+to allow for some discussion about the problem and proposed solution before significant
+time is invested.
+
+If you have not made an open-source contribution via a pull request before you may find
+this [detailed guide](https://www.asmeurer.com/git-workflow/) by [asmeurer](https://github.com/asmeurer)
+helpful. A summary of the main steps is as follows:
+
+1. [Fork the repository](https://github.com/matt-graham/mici/fork) and create a local clone of the fork.
+2. Create a new branch with a descriptive name in your fork clone.
+3. Make the proposed changes on the branch, giving each commit a descriptive commit message.
+4. Push the changes on the local branch to your fork on GitHub.
+5. Create a [pull request](https://github.com/matt-graham/mici/compare),
+   specifying the fork branch as the source of the changes,
+   giving the pull request a descriptive title and explaining what you are changing and why in the description.
+   If the pull-request is resolving a specific issue,
+   use [keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)
+   to link the appropriate issue.
+6. Make sure all automated status checks pass on the pull request.
+7. Await a review on the changes by one of the project maintainers, and address any review comments.
+8. Once all status checks pass and the changes have been approved by a maintainer the pull request can be merged.
+
+## Code style and linting
+
+Mici uses the [Black](https://black.readthedocs.io/en/stable/the_black_code_style/index.html) code style,
+and use [Ruff](https://docs.astral.sh/ruff/) to lint (and autoformat) the code.
+
+One way to ensure changes do not violate any of the rules Ruff checks for is to
+[install pre-commit](https://pre-commit.com/#install)
+and use it to install pre-commit hooks into your local clone of the repository
+using the configuration in [`.pre-commit-config.yaml`](.pre-commit-config.yaml) by running
+
+```bash
+pre-commit install
+```
+
+from the root of the repository.
+
+This will run a series of checks on any staged changes when attempting to make a commit,
+and flag if there are any problems with the changes. In some cases the problems may be
+automatically fixed where possible; in this case the updated changes will need to be
+staged and committed again.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Test status](https://github.com/matt-graham/mici/actions/workflows/tests.yml/badge.svg)](https://github.com/matt-graham/mici/actions/workflows/tests.yml)
 [![Linting status](https://github.com/matt-graham/mici/actions/workflows/linting.yml/badge.svg)](https://github.com/matt-graham/mici/actions/workflows/linting.yml)
 [![Docs status](https://github.com/matt-graham/mici/actions/workflows/docs.yml/badge.svg)](https://github.com/matt-graham/mici/actions/workflows/docs.yml)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 </div>
 </div>


### PR DESCRIPTION
Adds a code of conduct for contributors using [Contributors Covenant](https://www.contributor-covenant.org/) and basic guidelines for reporting bugs and making contributions.