### PR TITLE
Setting up codecov for coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13"
 
     steps:
       - name: Checkout source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Checkout source
@@ -52,3 +53,8 @@ jobs:
 
       - name: Test with tox
         run: tox
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Test status](https://github.com/matt-graham/mici/actions/workflows/tests.yml/badge.svg)](https://github.com/matt-graham/mici/actions/workflows/tests.yml)
 [![Linting status](https://github.com/matt-graham/mici/actions/workflows/linting.yml/badge.svg)](https://github.com/matt-graham/mici/actions/workflows/linting.yml)
 [![Docs status](https://github.com/matt-graham/mici/actions/workflows/docs.yml/badge.svg)](https://github.com/matt-graham/mici/actions/workflows/docs.yml)
+[![codecov](https://codecov.io/gh/matt-graham/mici/graph/badge.svg?token=YXC1A7WONK)](https://codecov.io/gh/matt-graham/mici)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ legacy_tox_ini = """
 
     [testenv]
     commands =
-        pytest --cov {posargs}
+        pytest --cov --cov-branch --cov-report=xml {posargs}
     extras =
         autograd
         jax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Typing :: Typed"
 ]
 dependencies = [
@@ -197,7 +196,6 @@ legacy_tox_ini = """
         3.10: py310
         3.11: py311
         3.12: py312
-        3.13: py313
 
     [testenv]
     commands =
@@ -228,5 +226,4 @@ legacy_tox_ini = """
         py310
         py311
         py312
-        py313
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Typing :: Typed"
 ]
 dependencies = [
@@ -196,6 +197,7 @@ legacy_tox_ini = """
         3.10: py310
         3.11: py311
         3.12: py312
+        3.13: py313
 
     [testenv]
     commands =
@@ -226,4 +228,5 @@ legacy_tox_ini = """
         py310
         py311
         py312
+        py313
 """


### PR DESCRIPTION
Updates `tox` test environment to generate XML coverage reports and associated `tests` GitHub Actions workflow to upload coverage reports to Codecov. ~~Also extends test matrix to include Python 3.13.~~