### PR TITLE
Avoid passing `shape=None` to NumPy functions

### DIFF
--- a/src/mici/matrices.py
+++ b/src/mici/matrices.py
@@ -532,7 +532,7 @@ class IdentityMatrix(PositiveDefiniteMatrix, ImplicitArrayMatrix):
 
     @property
     def diagonal(self) -> NDArray:
-        return np.ones(self.shape[0])
+        return np.ones(self.shape[0] if self.shape[0] is not None else ())
 
     def _construct_array(self) -> NDArray:
         if self.shape[0] is None:
@@ -642,7 +642,9 @@ class ScaledIdentityMatrix(SymmetricMatrix, DifferentiableMatrix, ImplicitArrayM
 
     @property
     def diagonal(self) -> NDArray:
-        return self._scalar * np.ones(self.shape[0])
+        return self._scalar * np.ones(
+            self.shape[0] if self.shape[0] is not None else ()
+        )
 
     def _construct_array(self) -> NDArray:
         if self.shape[0] is None:


### PR DESCRIPTION
Passing `shape=None` to NumPy functions with non-optional shape arguments raises an error in NumPy v2.3+ - there were a few cases of this in `src/mici/matrices.py` module causing test failures on latest scheduled workflow run.