### PR TITLE
Update version in docs automatically and link type aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,11 +9,12 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html#project-informatio
 """
 
 import collections
+from importlib.metadata import version as get_version
 
 project = "Mici"
 copyright = "2023, Matt Graham"  # noqa: A001
 author = "Matt Graham"
-release = "0.2.0"
+release = get_version("mici")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -92,6 +93,42 @@ def _remove_namedtuple_constructor_lines(_app, _what, _name, obj, _options, line
         lines.clear()
 
 
+# Currently Sphinx does not resolve links to type aliases correctly so we manually
+# enumerate type aliases here and add a hook to update these to the correct role type
+# so the links get resolved correctly
+# https://github.com/sphinx-doc/sphinx/issues/10785
+
+TYPE_ALIASES = [
+    "ScalarFunction",
+    "GradientFunction",
+    "ArrayFunction",
+    "JacobianFunction",
+    "TerminationCriterion",
+    "VectorJacobianProductFunction",
+    "MatrixHessianProductFunction",
+    "MetricLike",
+    "HessianFunction",
+    "MatrixTressianProductFunction",
+]
+
+
+def _resolve_type_aliases(app, env, node, contnode):
+    """Resolve :class: references to our type aliases as :data: instead.
+
+    Based on https://github.com/sphinx-doc/sphinx/issues/10785#issue-1348601826
+    """
+    if (
+        node["refdomain"] == "py"
+        and node["reftype"] == "class"
+        and node["reftarget"] in TYPE_ALIASES
+    ):
+        return app.env.get_domain("py").resolve_xref(
+            env, node["refdoc"], app.builder, "data", node["reftarget"], node, contnode
+        )
+    return None
+
+
 def setup(app):
     app.connect("autodoc-skip-member", _remove_namedtuple_attrib_docstring)
     app.connect("autodoc-process-docstring", _remove_namedtuple_constructor_lines)
+    app.connect("missing-reference", _resolve_type_aliases)


### PR DESCRIPTION
Uses `importlib.version` to pull in current package version automatically in Sphinx `docs/conf.py` configuration file and also adds hook to update links to type aliases in function API documentation to resolve correctly.