### PR TITLE
Fix bug in progress bar display when IPython installed but not used

### DIFF
--- a/src/mici/progressbars.py
+++ b/src/mici/progressbars.py
@@ -40,6 +40,8 @@ def _in_interactive_shell() -> bool:
         return True
     try:
         ipython = get_ipython()
+        if ipython is None:
+            return False
         ipython_module = ipython.__module__
         ipython_class = ipython.__class__.__name__
     except NameError:


### PR DESCRIPTION
Fixes a bug in `_in_interactive_shell` function which checks if currently running in an interactive shell, whereby if `IPython` is installed but not currently in use the `IPython.get_ipython` function will return `None` which causes the subsequent attempt to extract it's module and class names to fail.