### PR TITLE
Updates to interop module for ArviZ 1.0+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 ]
 dependencies = [
   "numpy>=1.22",
-  "scipy>=1.1"
+  "scipy>=1.1",
+  "packaging>=14.1"
 ]
 description = "MCMC samplers based on simulating Hamiltonian dynamics on a manifold."
 dynamic = [

--- a/src/mici/interop.py
+++ b/src/mici/interop.py
@@ -28,6 +28,29 @@ if TYPE_CHECKING:
     )
 
 
+def _preprocess_stats(
+    traces: dict[str, list[ArrayLike]],
+    stats: dict[str, list[ArrayLike]],
+    energy_key: str,
+    lp_key: str,
+) -> dict[str, list[ArrayLike]]:
+    """Preprocess statistics dictionary to normalize variable names."""
+    stats = stats.copy()
+    stats["n_steps"] = stats.pop("n_step")
+    stats["acceptance_rate"] = stats.pop("accept_stat")
+    if energy_key is not None and energy_key in traces:
+        stats["energy"] = traces[energy_key]
+    if lp_key is not None and lp_key in traces:
+        stats["lp"] = traces[lp_key]
+    return stats
+
+
+def _stack_arrays(data_dict: dict[str, list[ArrayLike]]) -> dict[str, ArrayLike]:
+    return {
+        key: np.stack(per_chain_arrays) for key, per_chain_arrays in data_dict.items()
+    }
+
+
 def convert_to_inference_data(
     traces: dict[str, list[ArrayLike]],
     stats: dict[str, list[ArrayLike]],
@@ -66,16 +89,57 @@ def convert_to_inference_data(
         msg = "InferenceData was removed in ArviZ v1.0+ in favour of xarray.DataTree"
         raise RuntimeError(msg)
 
-    stats = stats.copy()
-    stats["n_steps"] = stats.pop("n_step")
-    stats["acceptance_rate"] = stats.pop("accept_stat")
-    if energy_key is not None and energy_key in traces:
-        stats["energy"] = traces[energy_key]
-    if lp_key is not None and lp_key in traces:
-        stats["lp"] = traces[lp_key]
+    sample_stats = _preprocess_stats(traces, stats, energy_key, lp_key)
     return arviz.InferenceData(
         posterior=arviz.dict_to_dataset(traces, library=mici),
-        sample_stats=arviz.dict_to_dataset(stats, library=mici),
+        sample_stats=arviz.dict_to_dataset(sample_stats, library=mici),
+    )
+
+
+def convert_to_datatree(
+    traces: dict[str, list[ArrayLike]],
+    stats: dict[str, list[ArrayLike]],
+    energy_key: str | None = "energy",
+    lp_key: str | None = "lp",
+) -> arviz.InferenceData:
+    """Convert Mici :code:`sample_chains` output to ArviZ :py:class:`xarray.DataTree`.
+
+    Args:
+        traces: Traces output from Mici
+            :py:meth:`mici.samplers.MarkovChainMonteCarloMethod.sample_chains` call. A
+            dictionary of variables traced over sampled chains with the dictionary keys
+            the variable names and the values a list of arrays, one array per sampled
+            chain, with the first array dimension corresponding to the draw index and
+            any remaining dimensions, the variable dimensions.
+        stats: Statistics output from Mici `sample_chains` call. A dictionary of chain
+            statistics traced over sampled chains with the dictionary keys the
+            statistics names and the values a list of arrays, one array per sampled
+            chain, with the array dimension corresponding to the draw index.
+        energy_key: The key of an entry in the `traces` dictionary corresponding the
+            value of the Hamiltonian energy for the accepted proposal (up to an additive
+            constant). If present the corresponding values will be added to the
+            `sample_stats` group of the returned `InferenceData` object.
+        lp_key: The key of an entry in the `traces` dictionary corresponding the value
+            of the joint log posterior density for the model (up to an additive
+            constant). If present the corresponding values will be added to the
+            `sample_stats` group of the returned `InferenceData` object.
+
+    Returns:
+        DataTree object with traced chain data stored in the `posterior`
+        group and additional chain statistics in the `sample_stats` group.
+    """
+    import arviz
+
+    if parse_version(arviz.__version__) < parse_version("1.0.0"):
+        msg = "xarray.DataTree support requires ArviZ v1.0+"
+        raise RuntimeError(msg)
+
+    sample_stats = _preprocess_stats(traces, stats, energy_key, lp_key)
+    return arviz.from_dict(
+        {
+            "posterior": _stack_arrays(traces),
+            "sample_stats": _stack_arrays(sample_stats),
+        }
     )
 
 

--- a/src/mici/interop.py
+++ b/src/mici/interop.py
@@ -7,6 +7,7 @@ import os
 from typing import TYPE_CHECKING
 
 import numpy as np
+from packaging.version import parse as parse_version
 
 import mici
 
@@ -60,6 +61,10 @@ def convert_to_inference_data(
         group and additional chain statistics in the `sample_stats` group.
     """
     import arviz
+
+    if parse_version(arviz.__version__) >= parse_version("1.0.0"):
+        msg = "InferenceData was removed in ArviZ v1.0+ in favour of xarray.DataTree"
+        raise RuntimeError(msg)
 
     stats = stats.copy()
     stats["n_steps"] = stats.pop("n_step")

--- a/src/mici/interop.py
+++ b/src/mici/interop.py
@@ -96,7 +96,7 @@ def convert_to_inference_data(
     )
 
 
-def convert_to_datatree(
+def convert_to_data_tree(
     traces: dict[str, list[ArrayLike]],
     stats: dict[str, list[ArrayLike]],
     energy_key: str | None = "energy",

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -87,19 +87,19 @@ if ARVIZ_AVAILABLE:
         with pytest.raises(RuntimeError, match=r"InferenceData was removed"):
             mici.interop.convert_to_inference_data(traces, stats)
 
-    def test_convert_to_datatree(traces, stats):
+    def test_convert_to_data_tree(traces, stats):
         if parse_version(arviz.__version__) < parse_version("1.0.0"):
             pytest.skip("DataTree only available in ArviZ versions >= 1.0")
-        data_tree = mici.interop.convert_to_datatree(traces, stats)
+        data_tree = mici.interop.convert_to_data_tree(traces, stats)
         _check_arviz_data_object(data_tree, traces)
 
-    def test_convert_to_datatree_raises(traces, stats):
+    def test_convert_to_data_tree_raises(traces, stats):
         if parse_version(arviz.__version__) >= parse_version("1.0.0"):
             pytest.skip(
                 "DataTree available in ArviZ versions >= 1.0 so error not expected"
             )
         with pytest.raises(RuntimeError, match=r"xarray\.DataTree support"):
-            mici.interop.convert_to_datatree(traces, stats)
+            mici.interop.convert_to_data_tree(traces, stats)
 
 
 if PYMC_AVAILABLE:

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -2,6 +2,7 @@ import importlib
 
 import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 
 import mici
 
@@ -38,19 +39,29 @@ def rng():
     return np.random.default_rng(SEED)
 
 
+@pytest.fixture
+def traces(rng):
+    return {
+        "a": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
+        "b": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
+        "energy": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
+        "lp": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
+    }
+
+
+@pytest.fixture
+def stats(rng):
+    return {
+        "accept_stat": list(rng.uniform(0, 1, (NUM_CHAIN, NUM_SAMPLE))),
+        "n_step": list(rng.integers(0, 10, (NUM_CHAIN, NUM_SAMPLE))),
+    }
+
+
 if ARVIZ_AVAILABLE:
 
-    def test_convert_to_inference_data(rng):
-        traces = {
-            "a": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
-            "b": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
-            "energy": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
-            "lp": list(rng.standard_normal((NUM_CHAIN, NUM_SAMPLE))),
-        }
-        stats = {
-            "accept_stat": list(rng.uniform(0, 1, (NUM_CHAIN, NUM_SAMPLE))),
-            "n_step": list(rng.integers(0, 10, (NUM_CHAIN, NUM_SAMPLE))),
-        }
+    def test_convert_to_inference_data(traces, stats):
+        if parse_version(arviz.__version__) >= parse_version("1.0.0"):
+            pytest.skip("arviz.InferenceData only available in versions < 1.0")
         inference_data = mici.interop.convert_to_inference_data(traces, stats)
         assert isinstance(inference_data, arviz.InferenceData)
         groups = inference_data.groups()
@@ -66,6 +77,14 @@ if ARVIZ_AVAILABLE:
             "energy",
             "lp",
         }
+
+    def test_convert_to_inference_data_raises(traces, stats):
+        if parse_version(arviz.__version__) <= parse_version("1.0.0"):
+            pytest.skip(
+                "arviz.InferenceData available in versions < 1.0 so error not expected"
+            )
+        with pytest.raises(RuntimeError, match="InferenceData was removed"):
+            mici.interop.convert_to_inference_data(traces, stats)
 
 
 if PYMC_AVAILABLE:
@@ -98,6 +117,8 @@ if PYMC_AVAILABLE:
     if ARVIZ_AVAILABLE:
 
         def test_sample_pymc_model_inference_data(pymc_model):
+            if parse_version(arviz.__version__) >= parse_version("1.0.0"):
+                pytest.skip("arviz.InferenceData only available in versions < 1.0")
             inference_data = mici.interop.sample_pymc_model(
                 model=pymc_model,
                 chains=NUM_CHAIN,
@@ -153,6 +174,8 @@ if STAN_AVAILABLE:
     if ARVIZ_AVAILABLE:
 
         def test_sample_stan_model_inference_data(stan_model_code_data_and_params):
+            if parse_version(arviz.__version__) >= parse_version("1.0.0"):
+                pytest.skip("arviz.InferenceData only available in versions < 1.0")
             model_code, data, params = stan_model_code_data_and_params
             inference_data = mici.interop.sample_stan_model(
                 model_code=model_code,

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -59,32 +59,47 @@ def stats(rng):
 
 if ARVIZ_AVAILABLE:
 
-    def test_convert_to_inference_data(traces, stats):
-        if parse_version(arviz.__version__) >= parse_version("1.0.0"):
-            pytest.skip("arviz.InferenceData only available in versions < 1.0")
-        inference_data = mici.interop.convert_to_inference_data(traces, stats)
-        assert isinstance(inference_data, arviz.InferenceData)
-        groups = inference_data.groups()
-        assert "posterior" in groups
-        assert "sample_stats" in groups
-        for group in groups:
-            assert inference_data[group].coords["chain"].size == NUM_CHAIN
-            assert inference_data[group].coords["draw"].size == NUM_SAMPLE
-        assert set(inference_data.posterior.keys()) == set(traces.keys())
-        assert set(inference_data.sample_stats.keys()) == {
+    def _check_arviz_data_object(data, traces):
+        for group in ("posterior", "sample_stats"):
+            assert group in data
+            assert data[group].coords["chain"].size == NUM_CHAIN
+            assert data[group].coords["draw"].size == NUM_SAMPLE
+        assert set(data.posterior.keys()) == set(traces.keys())
+        assert set(data.sample_stats.keys()) == {
             "acceptance_rate",
             "n_steps",
             "energy",
             "lp",
         }
 
+    def test_convert_to_inference_data(traces, stats):
+        if parse_version(arviz.__version__) >= parse_version("1.0.0"):
+            pytest.skip("arviz.InferenceData only available in versions < 1.0")
+        inference_data = mici.interop.convert_to_inference_data(traces, stats)
+        assert isinstance(inference_data, arviz.InferenceData)
+        _check_arviz_data_object(inference_data, traces)
+
     def test_convert_to_inference_data_raises(traces, stats):
         if parse_version(arviz.__version__) <= parse_version("1.0.0"):
             pytest.skip(
                 "arviz.InferenceData available in versions < 1.0 so error not expected"
             )
-        with pytest.raises(RuntimeError, match="InferenceData was removed"):
+        with pytest.raises(RuntimeError, match=r"InferenceData was removed"):
             mici.interop.convert_to_inference_data(traces, stats)
+
+    def test_convert_to_datatree(traces, stats):
+        if parse_version(arviz.__version__) < parse_version("1.0.0"):
+            pytest.skip("DataTree only available in ArviZ versions >= 1.0")
+        data_tree = mici.interop.convert_to_datatree(traces, stats)
+        _check_arviz_data_object(data_tree, traces)
+
+    def test_convert_to_datatree_raises(traces, stats):
+        if parse_version(arviz.__version__) >= parse_version("1.0.0"):
+            pytest.skip(
+                "DataTree available in ArviZ versions >= 1.0 so error not expected"
+            )
+        with pytest.raises(RuntimeError, match=r"xarray\.DataTree support"):
+            mici.interop.convert_to_datatree(traces, stats)
 
 
 if PYMC_AVAILABLE:


### PR DESCRIPTION
Checks added for ArviZ versions in `convert_to_inference_data` function and corresponding tests as `InferenceData` support dropped in ArviZ versions 1.0 and above in favour of using `xarray.DataTree` objects. A new `convert_to_data_tree` function which handles conversion for ArviZ versions 1.0+ is also added and corresponding tests.